### PR TITLE
[eng 1339] number filters working bad with big numbers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skiff-org/prosemirror-tables",
-  "version": "3.0.8",
+  "version": "3.0.9",
   "description": "ProseMirror's rowspan/colspan tables component",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/src/columnsTypes/filtersLogic.js
+++ b/src/columnsTypes/filtersLogic.js
@@ -1,5 +1,5 @@
 import dayjs from 'dayjs';
-import { removeInvisibleCharacterFromText } from '../util';
+import {removeInvisibleCharacterFromText} from '../util';
 
 /**
  * This file contains all the filters logic
@@ -18,9 +18,9 @@ export const textInequality = (cell, value) => {
 };
 
 export const textContains = (cell, value) => {
-  return removeInvisibleCharacterFromText(cell.textContent.toLowerCase()).includes(
-    value.toLowerCase()
-  );
+  return removeInvisibleCharacterFromText(
+    cell.textContent.toLowerCase()
+  ).includes(value.toLowerCase());
 };
 
 export const textNotContains = (cell, value) => {
@@ -36,29 +36,32 @@ export const isTextNotEmpty = (cell) => {
 };
 
 // Number Logic
+const parseNum = (number) => {
+  return Number(number.trim().replaceAll(',', ''));
+};
 
 export const numberEquality = (cell, value) => {
-  return Number(cell.textContent) === Number(value);
+  return parseNum(cell.textContent) === parseNum(value);
 };
 
 export const numberInequality = (cell, value) => {
-  return Number(cell.textContent) !== Number(value);
+  return parseNum(cell.textContent) !== parseNum(value);
 };
 
 export const smallerOrEquals = (cell, value) => {
-  return Number(cell.textContent) <= Number(value);
+  return parseNum(cell.textContent) <= parseNum(value);
 };
 
 export const smaller = (cell, value) => {
-  return Number(cell.textContent) < Number(value);
+  return parseNum(cell.textContent) < parseNum(value);
 };
 
 export const greaterOrEquals = (cell, value) => {
-  return Number(cell.textContent) >= Number(value);
+  return parseNum(cell.textContent) >= parseNum(value);
 };
 
 export const greater = (cell, value) => {
-  return Number(cell.textContent) > Number(value);
+  return parseNum(cell.textContent) > parseNum(value);
 };
 
 export const isNumberEmpty = (cell) => {
@@ -128,7 +131,7 @@ export const isDateNotEmpty = (cell) => {
 // Currency Logic
 
 const removeCurrencyFromText = (text) => {
-  return text.replace('$', '').trim();
+  return text.replaceAll(/[\$,]/g, '').trim();
 };
 
 export const currencyEquality = (cell, value) => {

--- a/src/columnsTypes/utils.js
+++ b/src/columnsTypes/utils.js
@@ -9,11 +9,10 @@ export const parseTextToCurrency = (text, currency) => {
           .toString()
           .replace(/\B(?=(\d{3})+(?!\d))/g, ',')
     : `${currency} 0.00`;
-}
+};
 
 export const parseTextToNumber = (text) => {
-  const numbersInStringRegex = /[+-]?([0-9]+\.?[0-9]*|\.[0-9]+)/g;
+  const numbersInStringRegex = /(^[+-])?([0-9]+\.?[0-9]*|\.[0-9]+)/g;
   const matches = text.match(numbersInStringRegex);
-
   return matches ? matches.join('').replace(/\B(?=(\d{3})+(?!\d))/g, ',') : '';
-}
+};

--- a/src/columnsTypes/utils.js
+++ b/src/columnsTypes/utils.js
@@ -12,7 +12,19 @@ export const parseTextToCurrency = (text, currency) => {
 };
 
 export const parseTextToNumber = (text) => {
-  const numbersInStringRegex = /(^[+-])?([0-9]+\.?[0-9]*|\.[0-9]+)/g;
-  const matches = text.match(numbersInStringRegex);
-  return matches ? matches.join('').replace(/\B(?=(\d{3})+(?!\d))/g, ',') : '';
+  const numbersInText = text.match(/(^[+-])?([0-9]+\.?[0-9]*|\.[0-9]+)/g);
+  if (!numbersInText) return '';
+
+  const combined = [...numbersInText.join('')]
+    .map((char, index, array) => {
+      return char === '.' ? (index === array.indexOf('.') ? '.' : '') : char;
+    })
+    .join('');
+  const leftNumber = combined
+    .split('.')[0]
+    .replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+  const rightNumber = combined.split('.')[1]
+    ? `.${combined.split('.')[1]}`
+    : '';
+  return leftNumber + rightNumber;
 };


### PR DESCRIPTION
fixed numbers + currency cameraperson (removing the `,`)
removed -+ from numbers only leaves on start of number `-1-2 -> -12`
removed all `.` except one `1.2.3 -> 1.23`
adding `,` only on the left side of the dot `1234.1234 -> 1,234.1234`
https://skifftalk.slack.com/files/U021FV25RS4/F02LYUQB68P/tablesfiltersbugs.m

https://user-images.githubusercontent.com/10141414/141836249-1b00dbe3-7615-48c6-9496-851274a110cd.mov
