### PR TITLE
Aaronhorvath/eng 1986 cmda select all inside of a table cell

### DIFF
--- a/src/commands.js
+++ b/src/commands.js
@@ -1,5 +1,5 @@
 // This file defines a number of table-related commands.
-import {TextSelection, Selection} from 'prosemirror-state';
+import {TextSelection, Selection, NodeSelection} from 'prosemirror-state';
 import {Fragment} from 'prosemirror-model';
 import {
   findParentNodeOfTypeClosestToPos,
@@ -704,6 +704,18 @@ export function goToNextCell(direction) {
     }
     return true;
   };
+}
+export function selectCurrentCell(state, dispatch) {
+  const currentCell = selectionCell(state);
+  if (!currentCell) {
+    return false;
+  }
+  if (dispatch) {
+    const selection = new NodeSelection(currentCell);
+    dispatch(state.tr.setSelection(selection));
+    return true;
+  }
+  return false;
 }
 
 // :: (EditorState, ?(tr: Transaction)) → bool

--- a/src/commands.js
+++ b/src/commands.js
@@ -1,5 +1,5 @@
 // This file defines a number of table-related commands.
-import {TextSelection, Selection, NodeSelection} from 'prosemirror-state';
+import {TextSelection, Selection} from 'prosemirror-state';
 import {Fragment} from 'prosemirror-model';
 import {
   findParentNodeOfTypeClosestToPos,
@@ -711,7 +711,7 @@ export function selectCurrentCell(state, dispatch) {
     return false;
   }
   if (dispatch) {
-    const selection = new NodeSelection(currentCell);
+    const selection = new CellSelection(currentCell);
     dispatch(state.tr.setSelection(selection));
     return true;
   }

--- a/src/commands.js
+++ b/src/commands.js
@@ -705,6 +705,9 @@ export function goToNextCell(direction) {
     return true;
   };
 }
+
+// :: (EditorState, ?(tr: Transaction)) → bool
+// Selects the current cell the cursor is in
 export function selectCurrentCell(state, dispatch) {
   const currentCell = selectionCell(state);
   if (!currentCell) {

--- a/src/input.js
+++ b/src/input.js
@@ -23,6 +23,7 @@ import {
   deleteRow,
   deleteTable,
   selectedRect,
+  selectCurrentCell,
 } from './commands';
 import {columnTypesMap} from './columnsTypes/types.config';
 
@@ -42,6 +43,7 @@ export const handleKeyDown = keydownHandler({
   'Shift-ArrowRight': shiftArrow('horiz', 1),
   'Shift-ArrowUp': shiftArrow('vert', -1),
   'Shift-ArrowDown': shiftArrow('vert', 1),
+  'Mod-a': selectCurrentCell,
 
   Backspace: deleteCellSelection,
   'Mod-Backspace': deleteCellSelection,


### PR DESCRIPTION
Added keyHandler for  `Cmd+A` to select the cell the cursor is in instead of letting `czi-prosemirror` handle it which would select the whole doc.