### PR TITLE
Aaronhorvath/rename compatibility

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -384,3 +384,7 @@ export function getSelectedCellsCoords(
   width: number,
   height: number
 }
+
+export function setBaseName(
+  name: string
+)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skiff-org/prosemirror-tables",
-  "version": "3.3.2",
+  "version": "3.4.2",
   "description": "ProseMirror's rowspan/colspan tables component",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/src/columnsTypes/types/Date/datePopup.js
+++ b/src/columnsTypes/types/Date/datePopup.js
@@ -11,6 +11,7 @@ import {
 } from './utils';
 import {DatePickerComponent, datePopupEmitter} from './Component.jsx';
 import {findParentNodeOfType} from 'prosemirror-utils';
+import {getBaseName} from '../../../util';
 
 class TableDateMenuView {
   constructor(view) {
@@ -27,7 +28,7 @@ class TableDateMenuView {
 
     // the dom element that contains the popup - should be css relative
     this.popUpRelativeContainer = document.getElementsByClassName(
-      'czi-editor-frame-body'
+      `${getBaseName()}-editor-frame-body`
     )[0];
 
     const existingPopUps = Array.from(

--- a/src/columnsTypes/types/Date/utils.js
+++ b/src/columnsTypes/types/Date/utils.js
@@ -1,5 +1,6 @@
 import dayjs from 'dayjs';
 import {PluginKey} from 'prosemirror-state';
+import {getBaseName} from '../../../util';
 
 export let DATE_FORMAT = 'DD/MM/YYYY';
 export const setDateFormat = (format) => (DATE_FORMAT = format);
@@ -39,7 +40,9 @@ export const calculateMenuPosition = (menuDOM, {node, dom: cellDOM, pos}) => {
   if (left === 0 || bottom === 0 || cellHeight === 0 || top === 0) return;
 
   // scroll offset
-  const [scrolledEl] = document.getElementsByClassName('czi-editor-frame-body');
+  const [scrolledEl] = document.getElementsByClassName(
+    `${getBaseName()}-editor-frame-body`
+  );
   const {x: EDITOR_LEFT_OFFSET, y: EDITOR_TOP_OFFSET} =
     scrolledEl.getBoundingClientRect();
   let {height: menuHeight} = menuDOM.getBoundingClientRect();

--- a/src/columnsTypes/types/Label/labelPopup.js
+++ b/src/columnsTypes/types/Label/labelPopup.js
@@ -8,6 +8,7 @@ import {
   calculateMenuPosition
 } from './utils';
 import {LabelsChooser} from './Component.jsx';
+import {getBaseName} from '../../../util';
 
 class TableLabelsMenu {
   constructor(view) {
@@ -24,7 +25,7 @@ class TableLabelsMenu {
 
     // the dom element that contains the popup - should be css relative
     this.popUpRelativeContainer = document.getElementsByClassName(
-      'czi-editor-frame-body'
+      `${getBaseName()}-editor-frame-body`
     )[0];
 
     const existingPopUps = Array.from(

--- a/src/columnsTypes/types/Label/utils.js
+++ b/src/columnsTypes/types/Label/utils.js
@@ -1,7 +1,7 @@
 import {findParentNodeOfTypeClosestToPos} from 'prosemirror-utils';
 import {PluginKey} from 'prosemirror-state';
 import {createHash} from 'crypto';
-import {getColCells} from '../../../util';
+import {getBaseName, getColCells} from '../../../util';
 
 export const tableLabelsMenuKey = new PluginKey('TableLabelsMenu');
 
@@ -150,7 +150,9 @@ export const calculateMenuPosition = (menuDOM, {node, dom: cellDOM, pos}) => {
   if (left === 0 || top === 0) return;
 
   // scroll offset
-  const [scrolledEl] = document.getElementsByClassName('czi-editor-frame-body');
+  const [scrolledEl] = document.getElementsByClassName(
+    `${getBaseName()}-editor-frame-body`
+  );
   const {x: EDITOR_LEFT_OFFSET, y: EDITOR_TOP_OFFSET} =
     scrolledEl.getBoundingClientRect();
 

--- a/src/filters/filters-menu.js
+++ b/src/filters/filters-menu.js
@@ -10,6 +10,7 @@ import {
 } from './utils';
 import {TableFiltersComponent} from './Component.jsx';
 import {findParentNodeOfTypeClosestToPos} from 'prosemirror-utils';
+import {getBaseName} from '../util';
 
 class TableFiltersMenuView {
   constructor(view) {
@@ -26,7 +27,7 @@ class TableFiltersMenuView {
 
     // the dom element that contains the popup - should be css relative
     this.popUpRelativeContainer = document.getElementsByClassName(
-      'czi-editor-frame-body'
+      `${getBaseName()}-editor-frame-body`
     )[0];
 
     const existingPopUps = Array.from(

--- a/src/filters/utils.js
+++ b/src/filters/utils.js
@@ -1,6 +1,10 @@
 import {PluginKey} from 'prosemirror-state';
 import {columnTypesMap, types} from '../columnsTypes/types.config';
-import {getColIndex, removeInvisibleCharacterFromText} from '../util';
+import {
+  getBaseName,
+  getColIndex,
+  removeInvisibleCharacterFromText,
+} from '../util';
 
 export const tableFiltersMenuKey = new PluginKey('TableFiltersMenu');
 
@@ -33,7 +37,9 @@ export const calculateMenuPosition = (menuDOM, {dom: tableDOM}) => {
   if (left === 0 || top === 0 || cellHeight === 0) return;
 
   // scroll offset
-  const [scrolledEl] = document.getElementsByClassName('czi-editor-frame-body');
+  const [scrolledEl] = document.getElementsByClassName(
+    `${getBaseName()}-editor-frame-body`
+  );
   const {x: EDITOR_LEFT_OFFSET, y: EDITOR_TOP_OFFSET} =
     scrolledEl.getBoundingClientRect();
 

--- a/src/headers/headers-menu/menu-view.js
+++ b/src/headers/headers-menu/menu-view.js
@@ -4,7 +4,7 @@ import {dropdownClassName} from './items';
 import {TextField} from './textField/text-field.prosemirror';
 import {tableHeadersMenuKey} from '../../columnsTypes/types.config';
 import {columnTypesMap} from '../../columnsTypes/types.config';
-import {createElementWithClass} from '../../util';
+import {createElementWithClass, getBaseName} from '../../util';
 
 /**
  * class attached to the editor and update table tooltip on every view update.
@@ -68,7 +68,7 @@ class TableHeadersMenuView {
 
     // the dom element that contains the popup - should be css relative
     this.popUpRelativeContainer = document.getElementsByClassName(
-      'czi-editor-frame-body'
+      `${getBaseName()}-editor-frame-body`
     )[0];
 
     const existingPopUps = Array.from(

--- a/src/headers/headers-menu/utils.js
+++ b/src/headers/headers-menu/utils.js
@@ -3,6 +3,7 @@ import {createElementWithClass, isInTable} from '../..//util';
 import {tableHeadersMenuKey} from '../../columnsTypes/types.config';
 import {findParentNodeOfType} from 'prosemirror-utils';
 import {isCellInFirstRow} from '../../columnsTypes/utils';
+import {getBaseName} from '../../util';
 
 export function enableDeleteItem(view) {
   const {selection: sel} = view.state;
@@ -65,7 +66,9 @@ export const calculateMenuPosition = (menuDOM, {node, dom: headerDOM, pos}) => {
   const {width: menuWidth} = menuDOM.getBoundingClientRect();
 
   // scroll offset
-  const [scrolledEl] = document.getElementsByClassName('czi-editor-frame-body');
+  const [scrolledEl] = document.getElementsByClassName(
+    `${getBaseName()}-editor-frame-body`
+  );
   const {x: EDITOR_LEFT_OFFSET, y: EDITOR_TOP_OFFSET} =
     scrolledEl.getBoundingClientRect();
 

--- a/src/index.js
+++ b/src/index.js
@@ -111,7 +111,8 @@ export {
   pointsAtCell,
   removeColSpan,
   addColSpan,
-  columnIsHeader
+  columnIsHeader,
+  setBaseName
 } from './util';
 export {tableNodes, tableNodeTypes} from './schema/schema';
 export {NodeNames} from './schema/nodeNames';

--- a/src/tooltip-menus/menu-view.js
+++ b/src/tooltip-menus/menu-view.js
@@ -8,6 +8,7 @@ import {
 } from './utils';
 import {renderGrouped} from 'prosemirror-menu';
 import {tooltips} from './items';
+import {getBaseName} from '../util';
 
 /**
  * class attached to the editor and update table tooltip on every view update.
@@ -22,7 +23,7 @@ class TablePopUpMenuView {
 
     // the dom element that contains the popup - should be css relative
     this.popUpRelativeContainer = document.getElementsByClassName(
-      'czi-editor-frame-body'
+      `${getBaseName()}-editor-frame-body`
     )[0];
 
     // sometimes there is already an instance of the popup - TODO: understand why...

--- a/src/tooltip-menus/utils.js
+++ b/src/tooltip-menus/utils.js
@@ -1,5 +1,5 @@
 import {CellSelection} from '../cellselection';
-import {createElementWithClass} from '../util';
+import {createElementWithClass, getBaseName} from '../util';
 
 export function enableDeleteItem(view) {
   const {selection: sel} = view.state;
@@ -90,7 +90,9 @@ export const calculatePopupPosition = (view, popupDOM) => {
   const offsetParentBox = popupDOM.offsetParent.getBoundingClientRect();
 
   // scroll offset
-  const [scrolledEl] = document.getElementsByClassName('czi-editor-frame-body');
+  const [scrolledEl] = document.getElementsByClassName(
+    `${getBaseName()}-editor-frame-body`
+  );
   const {x: EDITOR_LEFT_OFFSET, y: EDITOR_TOP_OFFSET} =
     scrolledEl.getBoundingClientRect();
 

--- a/src/util.js
+++ b/src/util.js
@@ -9,6 +9,10 @@ import {CellSelection} from './cellselection';
 
 export const key = new PluginKey('selectingCells');
 
+export function getBaseName(name = 'czi') {
+  return name;
+}
+
 export function cellAround($pos) {
   for (let d = $pos.depth - 1; d > 0; d--)
     if ($pos.node(d).type.spec.tableRole == 'row')

--- a/src/util.js
+++ b/src/util.js
@@ -8,9 +8,13 @@ import {selectedRect} from './commands';
 import {CellSelection} from './cellselection';
 
 export const key = new PluginKey('selectingCells');
+let baseName = 'czi';
 
-export function getBaseName(name = 'czi') {
-  return name;
+export function setBaseName(name) {
+  baseName = name;
+}
+export function getBaseName() {
+  return baseName;
 }
 
 export function cellAround($pos) {


### PR DESCRIPTION
exported a function that can replace the `czi` prefix to some other string in selectors. We can rename czi-prosemirror to skiff-prosemirror and call `setBaseName('skiff')` in ~~buildEditorInputs()~~ `buildEditorPlugins` and the tables plugin will still work. After merging te rename we can remove this. 