### PR TITLE
Copy Date column content instead of fixing it on paste

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skiff-org/prosemirror-tables",
-  "version": "3.4.21",
+  "version": "3.5.21",
   "description": "ProseMirror's rowspan/colspan tables component",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/src/columnsTypes/types/Date/Component.jsx
+++ b/src/columnsTypes/types/Date/Component.jsx
@@ -1,4 +1,4 @@
-import React, {useState, useCallback, useEffect} from 'react';
+import React, {useState, useCallback} from 'react';
 import useClickOutside from '../../../useClickOutside.jsx';
 import EditorContent from '../../../ReactNodeView/EditorContent.jsx';
 import {
@@ -43,20 +43,6 @@ const DateComponent = ({view, node, getPos, editorContentRef, dom}) => {
 
     view.dispatch(tr);
   };
-
-  const pos = getPos();
-
-  useEffect(() => {
-    const dateFromAttrs = node.attrs.value;
-    if (dateFromAttrs === -1 || !pos) return;
-    const formattedDate = formatDate(new Date(dateFromAttrs), DATE_FORMAT);
-    if (formattedDate !== node.textContent) {
-      const {tr} = view.state;
-      tr.insertText(formattedDate, pos + 1, pos + node.nodeSize - 1);
-
-      view.dispatch(tr);
-    }
-  }, [pos]);
 
   return (
     <div

--- a/src/columnsTypes/typesMenuItems.js
+++ b/src/columnsTypes/typesMenuItems.js
@@ -20,8 +20,8 @@ export const getTypesItems = () => {
     return new MenuItem({
       render: () => dom,
       class: 'typeItem',
-      run(state, dispatch, view) {
-        return type.handler.convert(view, type.id);
+      run(_state, dispatch, view) {
+        return type.handler.convert(dispatch, view, type.id);
       }
     });
   });

--- a/src/schema/schema.js
+++ b/src/schema/schema.js
@@ -183,7 +183,8 @@ export function tableNodes(options) {
           {
             class: 'cell-date',
             ...setNodeAttrs(node, dateExtraAttrs)
-          }
+          },
+          0
         ];
       }
     },


### PR DESCRIPTION
Second attempt at fixing [ENG-3261 Column type date causes an infinity column issue](https://linear.app/skiff/issue/ENG-3261/column-type-date-causes-an-infinity-column-issue) - replaces https://github.com/skiff-org/prosemirror-tables/pull/34 . Instead of normalizing Dates on paste, this version tells Prosemirror to include their content on copy - a one-line fix.

**Changes**
- Remove `useEffect` in Date's `Component.jsx`, which was causing infinity column bug when pasting a Date column.
  - That code was meant to fill in Date cells' text after pasting. However, this `useEffect` was too aggressive (running on every collaborator, maybe multiple times) and sometimes used wrong positions, causing new columns to appear.
- Instead, instruct Prosemirror to copy a Date cell's content, not just its outer node, by changing its `toDOM()` spec (in `schema/schema.js`).
- Refactor `typesMenuItems` to use the command pattern described in Prosemirror's docs. I didn't notice any bugs before, but in principle the old code could have caused similar extra transactions, by running even when the command's `dispatch` wasn't given.

**Testing**
See Linear for how to test yourself.

- Manual:
  - Pasting the problem table (see Linear) into a doc with 6 active viewers works: Date cells show up as in the original, and no new columns appear. (Note you have to copy the table from an env using this fixed version. E.g., paste the table from Linear into your local dev env, fill in the now-blank dates manually, then copy that table.)
  - Pasting the table into an existing table works as well as before.
  - Reloading an existing doc with a Date column works (the textContent still shows up).
  - Editing Date cells works as before.
  - Adding new rows works as well as before.