### PR TITLE
[ENG-3305] Run typeInheritance on created cells directly

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skiff-org/prosemirror-tables",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "description": "ProseMirror's rowspan/colspan tables component",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/src/columnsTypes/typeInheritance.js
+++ b/src/columnsTypes/typeInheritance.js
@@ -16,7 +16,6 @@ import {TableMap} from '../tablemap';
 export const typeInheritance = (tr, tableStart) => {
   // Subtract one to go from tableStart (start of first row) to actual table node's pos.
   const table = tr.doc.nodeAt(tableStart - 1);
-  console.log(table, tr.steps, 'before');
 
   if (!table.attrs.headers || !table.maybeChild(0)) return tr;
 
@@ -55,7 +54,7 @@ export const typeInheritance = (tr, tableStart) => {
         });
 
         // create cell content according to type
-        const cellContent = cell.type.createAndFill(
+        const updatedCellWithContent = cell.type.createAndFill(
           newAttrs,
           typeHandler.renderContentNode(
             table.type.schema,
@@ -66,11 +65,14 @@ export const typeInheritance = (tr, tableStart) => {
         );
 
         // replace the cell with new cell with updated type and content
-        tr.replaceRangeWith(cellPos, cellPos + cell.nodeSize, cellContent);
+        tr.replaceRangeWith(
+          cellPos,
+          cellPos + cell.nodeSize,
+          updatedCellWithContent
+        );
       }
     }
   }
-  const table1 = tr.doc.nodeAt(tableStart - 1);
-  console.log(table1, tr.steps, 'after');
+
   return tr;
 };

--- a/src/columnsTypes/typeInheritance.js
+++ b/src/columnsTypes/typeInheritance.js
@@ -9,18 +9,19 @@ import {TableMap} from '../tablemap';
  * new or their column type was changed.
  *
  * @param tr A transaction to add the changes to
- * @param table A Node of type schema.types.table. This Node should come from tr.doc,
- * so that its positions can be used in tr methods.
- * @param tableStart table's tableStart position, i.e., the pos of the first row
- * (1 + pos of table itself)
+ * @param tableStart The table's tableStart position, i.e., the pos of the first row
+ * (1 + pos of table itself) relative to tr.doc
  * @return tr
  */
-export const typeInheritance = (tr, table, tableStart) => {
+export const typeInheritance = (tr, tableStart) => {
+  // Subtract one to go from tableStart (start of first row) to actual table node's pos.
+  const table = tr.doc.nodeAt(tableStart - 1);
+
   if (!table.attrs.headers || !table.maybeChild(0)) return tr;
 
   // Store col types in colTypes (null if we should skip checking the column).
   // we don't allow cells merging, so we fill comfortable to check only the first row
-  const tableMap = TableMap.get(table);
+  const tableMap = TableMap.get(table); // Will error if table is not a table
   const colTypes = [];
   for (let col = tableMap.width - 1; col >= 0; col--) {
     if (!table.child(0).maybeChild(col)) colTypes[col] = null;

--- a/src/columnsTypes/typeInheritance.js
+++ b/src/columnsTypes/typeInheritance.js
@@ -1,28 +1,53 @@
 import {columnTypesMap} from './types.config';
 import {TableMap} from '../tablemap';
 
-export const typeInheritance = (view, node, pos) => {
-  if (!view || !node) return;
-  // we don't allow cells merging, so we fill comfortable to check only the first row
-  const tableMap = TableMap.get(node);
-  const {tr} = view.state;
-  for (let col = tableMap.width - 1; col >= 0; col--) {
-    if (!node.child(0) || !node.child(0).maybeChild(col)) continue;
-    const header = node.child(0).child(col);
-    const colType = header.attrs.type;
+/**
+ * Updates cells within table to inherit types from their column headers,
+ * setting attrs.type and rendering the type-appropriate content for cell.
+ *
+ * Call this whenever cells may have the wrong type, either because they are
+ * new or their column type was changed.
+ *
+ * @param tr A transaction to add the changes to
+ * @param table A Node of type schema.types.table. This Node should come from tr.doc,
+ * so that its positions can be used in tr methods.
+ * @param pos table's position
+ * @return tr
+ */
+export const typeInheritance = (tr, table, pos) => {
+  if (!table.attrs.headers || !table.maybeChild(0)) return tr;
 
-    for (let row = tableMap.height - 1; row >= 0; row--) {
-      if (!node.child(row) || !node.child(row).maybeChild(col)) continue;
-      const cell = node.child(row).maybeChild(col);
+  // Store col types in colTypes (null if we should skip checking the column).
+  // we don't allow cells merging, so we fill comfortable to check only the first row
+  const tableMap = TableMap.get(table);
+  const colTypes = [];
+  for (let col = tableMap.width - 1; col >= 0; col--) {
+    if (!table.child(0).maybeChild(col)) colTypes[col] = null;
+    else {
+      const header = table.child(0).child(col);
+      colTypes[col] = header.attrs.type;
+    }
+  }
+
+  // Loop through cells in reverse node order, so that we don't have to map
+  // positions through previous steps or refresh tableMap.
+  // Since the order is row-major, this means reverse row order, then reverse column order.
+  for (let row = tableMap.height - 1; row >= 0; row--) {
+    if (!table.maybeChild(row)) continue;
+    for (let col = tableMap.width - 1; col >= 0; col--) {
+      const colType = colTypes[col];
+      if (colType === null || !table.child(row).maybeChild(col)) continue;
+
+      const cell = table.child(row).maybeChild(col);
       if (cell.attrs.type !== colType) {
-        const cellPos = tableMap.map[row * tableMap.width + col] + pos + 1;
+        const cellPos = tableMap.map[row * tableMap.width + col] + pos;
         const typeHandler = columnTypesMap[colType].handler;
 
         tr.replaceRangeWith(
           cellPos + 1,
           cellPos + cell.nodeSize - 1,
           typeHandler.renderContentNode(
-            view.state.schema,
+            table.type.schema,
             typeHandler.convertContent(cell),
             tr,
             cellPos
@@ -38,5 +63,5 @@ export const typeInheritance = (view, node, pos) => {
     }
   }
 
-  if (tr.steps.length) view.dispatch(tr);
+  return tr;
 };

--- a/src/columnsTypes/typeInheritance.js
+++ b/src/columnsTypes/typeInheritance.js
@@ -11,10 +11,11 @@ import {TableMap} from '../tablemap';
  * @param tr A transaction to add the changes to
  * @param table A Node of type schema.types.table. This Node should come from tr.doc,
  * so that its positions can be used in tr methods.
- * @param pos table's position
+ * @param tableStart table's tableStart position, i.e., the pos of the first row
+ * (1 + pos of table itself)
  * @return tr
  */
-export const typeInheritance = (tr, table, pos) => {
+export const typeInheritance = (tr, table, tableStart) => {
   if (!table.attrs.headers || !table.maybeChild(0)) return tr;
 
   // Store col types in colTypes (null if we should skip checking the column).
@@ -40,7 +41,7 @@ export const typeInheritance = (tr, table, pos) => {
 
       const cell = table.child(row).maybeChild(col);
       if (cell.attrs.type !== colType) {
-        const cellPos = tableMap.map[row * tableMap.width + col] + pos;
+        const cellPos = tableMap.map[row * tableMap.width + col] + tableStart;
         const typeHandler = columnTypesMap[colType].handler;
 
         tr.replaceRangeWith(

--- a/src/columnsTypes/typeInheritance.js
+++ b/src/columnsTypes/typeInheritance.js
@@ -40,7 +40,7 @@ export const typeInheritance = (tr, tableStart) => {
       const colType = colTypes[col];
       if (colType === null || !table.child(row).maybeChild(col)) continue;
 
-      const cell = table.child(row).maybeChild(col);
+      const cell = table.child(row).child(col);
       if (cell.attrs.type !== colType) {
         const cellPos = tableMap.map[row * tableMap.width + col] + tableStart;
         const typeHandler = columnTypesMap[colType].handler;

--- a/src/columnsTypes/typeInheritance.js
+++ b/src/columnsTypes/typeInheritance.js
@@ -27,7 +27,7 @@ export const typeInheritance = (tr, tableStart) => {
     if (!table.child(0).maybeChild(col)) colTypes[col] = null;
     else {
       const header = table.child(0).child(col);
-      colTypes[col] = header.attrs.type;
+      colTypes[col] = header.attrs.type ?? 'text';
     }
   }
 

--- a/src/columnsTypes/types/Checkbox.js
+++ b/src/columnsTypes/types/Checkbox.js
@@ -1,4 +1,5 @@
 import CellDataType from './Type';
+import {NodeNames} from '../../schema/nodeNames';
 
 class CheckboxType extends CellDataType {
   /**
@@ -15,6 +16,15 @@ class CheckboxType extends CellDataType {
     return schema.nodes.checkbox.create({
       checked: typeof checked === 'boolean' ? checked : false
     });
+  }
+
+  /**
+   * check cell content is valid for the current type
+   */
+  validateContent(cell) {
+    return (
+      cell.childCount === 1 && cell.firstChild.type.name === NodeNames.CHECKBOX
+    );
   }
 }
 

--- a/src/columnsTypes/types/Currency.js
+++ b/src/columnsTypes/types/Currency.js
@@ -7,6 +7,13 @@ class CurrencyCellType extends CellDataType {
   convertContent(cell, convertFromType) {
     return parseTextToCurrency(cell.textContent, CURRENCY);
   }
+
+  /**
+   * check cell content is valid for the current type
+   */
+  validateContent(cell) {
+    return cell.firstChild.textContent.includes(CURRENCY);
+  }
 }
 
 export default CurrencyCellType;

--- a/src/columnsTypes/types/Date/Handler.js
+++ b/src/columnsTypes/types/Date/Handler.js
@@ -1,5 +1,6 @@
 import CellDataType from '../Type';
 import {buildDateObjectFromText, DATE_FORMAT, formatDate} from './utils';
+import {NodeNames} from '../../../schema/nodeNames';
 
 class DateType extends CellDataType {
   /**
@@ -22,6 +23,15 @@ class DateType extends CellDataType {
       dateInMili !== -1
         ? [schema.text(formatDate(new Date(dateInMili), DATE_FORMAT))]
         : []
+    );
+  }
+
+  /**
+   * check cell content is valid for the current type
+   */
+  validateContent(cell) {
+    return (
+      cell.childCount === 1 && cell.firstChild.type.name === NodeNames.DATE
     );
   }
 }

--- a/src/columnsTypes/types/Label/Handler.js
+++ b/src/columnsTypes/types/Label/Handler.js
@@ -1,6 +1,7 @@
 import CellDataType from '../Type';
 import {randomString, stringToColor, updateTablesLabels} from './utils';
 import {findParentNodeOfTypeClosestToPos} from 'prosemirror-utils';
+import {NodeNames} from '../../../schema/nodeNames';
 
 class LabelType extends CellDataType {
   /**
@@ -47,6 +48,15 @@ class LabelType extends CellDataType {
     return schema.nodes.label.create({
       labels
     });
+  }
+
+  /**
+   * check cell content is valid for the current type
+   */
+  validateContent(cell) {
+    return (
+      cell.childCount === 1 && cell.firstChild.type.name === NodeNames.LABEL
+    );
   }
 }
 

--- a/src/columnsTypes/types/Type.js
+++ b/src/columnsTypes/types/Type.js
@@ -82,6 +82,13 @@ class CellDataType {
     }
     return [];
   }
+
+  /**
+   * check cell content is valid for the current type
+   */
+  validateContent(_cell) {
+    return true;
+  }
 }
 
 export default CellDataType;

--- a/src/commands.js
+++ b/src/commands.js
@@ -198,8 +198,8 @@ export function addRow(tr, {map, tableStart, table}, row) {
     }
   }
   tr.insert(rowPos, tableNodeTypes(table.type.schema).row.create(null, cells));
-  typeInheritance(tr, tableStart);
   tr.setSelection(TextSelection.near(tr.doc.resolve(rowPos)));
+  typeInheritance(tr, tableStart);
   return tr;
 }
 

--- a/src/commands.js
+++ b/src/commands.js
@@ -87,7 +87,7 @@ export function addColumn(tr, {map, tableStart, table}, col) {
       );
     }
   }
-  typeInheritance(tr, tr.doc.nodeAt(tableStart - 1), tableStart);
+  typeInheritance(tr, tableStart);
 
   return tr;
 }
@@ -198,7 +198,7 @@ export function addRow(tr, {map, tableStart, table}, row) {
     }
   }
   tr.insert(rowPos, tableNodeTypes(table.type.schema).row.create(null, cells));
-  typeInheritance(tr, tr.doc.nodeAt(tableStart - 1), tableStart);
+  typeInheritance(tr, tableStart);
   tr.setSelection(TextSelection.near(tr.doc.resolve(rowPos)));
   return tr;
 }

--- a/src/commands.js
+++ b/src/commands.js
@@ -21,6 +21,7 @@ import {
   sortNumVsString
 } from './util';
 import {tableNodeTypes} from './schema/schema';
+import {typeInheritance} from './columnsTypes/typeInheritance';
 
 const MAX_COLS = 500;
 
@@ -165,6 +166,8 @@ export function rowIsHeader(map, table, row) {
   return true;
 }
 
+// Note: tableStart is the start of the first row, not the position
+// of table itself.
 export function addRow(tr, {map, tableStart, table}, row) {
   let rowPos = tableStart;
   for (let i = 0; i < row; i++) rowPos += table.child(i).nodeSize;
@@ -196,6 +199,9 @@ export function addRow(tr, {map, tableStart, table}, row) {
     }
   }
   tr.insert(rowPos, tableNodeTypes(table.type.schema).row.create(null, cells));
+  // Need to subtract 1 from tableStart to get the actual table node position.
+  // (We get it from tr.doc instead of using table b/c we want the new tr.doc version.)
+  typeInheritance(tr, tr.doc.nodeAt(tableStart - 1), tableStart);
   tr.setSelection(TextSelection.near(tr.doc.resolve(rowPos)));
   return tr;
 }

--- a/src/commands.js
+++ b/src/commands.js
@@ -87,6 +87,7 @@ export function addColumn(tr, {map, tableStart, table}, col) {
       );
     }
   }
+  typeInheritance(tr, tr.doc.nodeAt(tableStart - 1), tableStart);
 
   return tr;
 }
@@ -166,8 +167,6 @@ export function rowIsHeader(map, table, row) {
   return true;
 }
 
-// Note: tableStart is the start of the first row, not the position
-// of table itself.
 export function addRow(tr, {map, tableStart, table}, row) {
   let rowPos = tableStart;
   for (let i = 0; i < row; i++) rowPos += table.child(i).nodeSize;
@@ -199,8 +198,6 @@ export function addRow(tr, {map, tableStart, table}, row) {
     }
   }
   tr.insert(rowPos, tableNodeTypes(table.type.schema).row.create(null, cells));
-  // Need to subtract 1 from tableStart to get the actual table node position.
-  // (We get it from tr.doc instead of using table b/c we want the new tr.doc version.)
   typeInheritance(tr, tr.doc.nodeAt(tableStart - 1), tableStart);
   tr.setSelection(TextSelection.near(tr.doc.resolve(rowPos)));
   return tr;
@@ -291,6 +288,7 @@ export function removeRow(tr, {map, table, tableStart}, row) {
       const newPos = map.positionAt(row + 1, col, table);
       tr.insert(tr.mapping.slice(mapFrom).map(tableStart + newPos), copy);
       col += cell.attrs.colspan - 1;
+      // TODO: typeInheritance
     }
   }
 }
@@ -406,6 +404,7 @@ export function mergeCells(state, dispatch) {
       const start = isEmpty(mergedCell) ? mergedPos + 1 : end;
       tr.replaceWith(start + rect.tableStart, end + rect.tableStart, content);
     }
+    // TODO: typeInheritance
     tr.setSelection(
       new CellSelection(tr.doc.resolve(mergedPos + rect.tableStart))
     );
@@ -484,6 +483,7 @@ export function splitCellWithType(getCellType) {
             lastCell && tr.doc.resolve(lastCell)
           )
         );
+      // TODO: typeInheritance
       dispatch(tr);
     }
     return true;
@@ -782,6 +782,7 @@ export function sortColumn(view, colNumber, pos, dir) {
     )
   );
 
+  // No need for typeInheritance because we haven't changed the column's type or added new cells
   tr.replaceWith(rect.tableStart, rect.tableStart + rect.table.content.size, [
     header,
     ...newRowsArray

--- a/src/commands.js
+++ b/src/commands.js
@@ -87,7 +87,8 @@ export function addColumn(tr, {map, tableStart, table}, col) {
       );
     }
   }
-  typeInheritance(tr, tableStart);
+  // TODO: If we allow non-text columns / text cells needed rendering, we'd need typeInheritance:
+  // typeInheritance(tr, tableStart);
 
   return tr;
 }

--- a/src/copypaste.js
+++ b/src/copypaste.js
@@ -203,7 +203,7 @@ function growTable(tr, map, table, start, width, height, mapFrom) {
     tr.insert(tr.mapping.slice(mapFrom).map(start + table.nodeSize - 2), rows);
   }
   if (empty || emptyHead) {
-    typeInheritance(tr, tr.doc.nodeAt(start - 1), start);
+    typeInheritance(tr, start);
     return true;
   } else return false;
 }
@@ -314,7 +314,7 @@ export function insertCells(state, dispatch, tableStart, rect, cells) {
     );
   }
   recomp();
-  typeInheritance(tr, table, tableStart);
+  typeInheritance(tr, tableStart);
   tr.setSelection(
     new CellSelection(
       tr.doc.resolve(tableStart + map.positionAt(top, left, table)),

--- a/src/copypaste.js
+++ b/src/copypaste.js
@@ -313,8 +313,8 @@ export function insertCells(state, dispatch, tableStart, rect, cells) {
       new Slice(cells.rows[row - top], 0, 0)
     );
   }
-  recomp();
   typeInheritance(tr, tableStart);
+  recomp();
   tr.setSelection(
     new CellSelection(
       tr.doc.resolve(tableStart + map.positionAt(top, left, table)),

--- a/src/copypaste.js
+++ b/src/copypaste.js
@@ -17,6 +17,7 @@ import {setAttr, removeColSpan} from './util';
 import {TableMap} from './tablemap';
 import {CellSelection} from './cellselection';
 import {tableNodeTypes} from './schema/schema';
+import {typeInheritance} from './columnsTypes/typeInheritance';
 
 // Utilities to help with copying and pasting table cells
 
@@ -201,7 +202,10 @@ function growTable(tr, map, table, start, width, height, mapFrom) {
     for (let i = map.height; i < height; i++) rows.push(emptyRow);
     tr.insert(tr.mapping.slice(mapFrom).map(start + table.nodeSize - 2), rows);
   }
-  return !!(empty || emptyHead);
+  if (empty || emptyHead) {
+    typeInheritance(tr, tr.doc.nodeAt(start - 1), start);
+    return true;
+  } else return false;
 }
 
 // Make sure the given line (left, top) to (right, top) doesn't cross
@@ -231,6 +235,7 @@ function isolateHorizontal(tr, map, table, start, left, right, top, mapFrom) {
       col += cell.attrs.colspan - 1;
     }
   }
+  // TODO: typeInheritance
   return found;
 }
 
@@ -264,6 +269,7 @@ function isolateVertical(tr, map, table, start, top, bottom, left, mapFrom) {
       row += cell.attrs.rowspan - 1;
     }
   }
+  // TODO: typeInheritance
   return found;
 }
 
@@ -308,6 +314,7 @@ export function insertCells(state, dispatch, tableStart, rect, cells) {
     );
   }
   recomp();
+  typeInheritance(tr, table, tableStart);
   tr.setSelection(
     new CellSelection(
       tr.doc.resolve(tableStart + map.positionAt(top, left, table)),

--- a/src/fixtables.js
+++ b/src/fixtables.js
@@ -7,6 +7,7 @@ import {PluginKey} from 'prosemirror-state';
 import {TableMap} from './tablemap';
 import {setAttr, removeColSpan} from './util';
 import {tableNodeTypes} from './schema/schema';
+import {typeInheritance} from './columnsTypes/typeInheritance';
 
 export const fixTablesKey = new PluginKey('fix-tables');
 
@@ -123,5 +124,6 @@ export function fixTable(state, table, tablePos, tr) {
     }
     pos = end;
   }
+  typeInheritance(tr, tr.doc.nodeAt(tablePos), tablePos + 1);
   return tr.setMeta(fixTablesKey, {fixTables: true});
 }

--- a/src/fixtables.js
+++ b/src/fixtables.js
@@ -124,6 +124,6 @@ export function fixTable(state, table, tablePos, tr) {
     }
     pos = end;
   }
-  typeInheritance(tr, tr.doc.nodeAt(tablePos), tablePos + 1);
+  typeInheritance(tr, tablePos + 1);
   return tr.setMeta(fixTablesKey, {fixTables: true});
 }

--- a/src/fixtables.js
+++ b/src/fixtables.js
@@ -118,7 +118,9 @@ export function fixTable(state, table, tablePos, tr) {
       }
       const nodes = [];
       for (let j = 0; j < add; j++)
-        nodes.push(tableNodeTypes(state.schema)[tableNodeType].createAndFill());
+        nodes.push(
+          tableNodeTypes(state.schema)[tableNodeType].createAndFill({})
+        );
       const side = (i == 0 || first == i - 1) && last == i ? pos + 1 : end - 1;
       tr.insert(tr.mapping.map(side), nodes);
     }

--- a/src/headers/headers-menu/index.js
+++ b/src/headers/headers-menu/index.js
@@ -40,5 +40,3 @@ export const tableHeadersMenu = () => {
     }
   });
 };
-
-export {typeInheritance} from '../../columnsTypes/typeInheritance';

--- a/src/table-dragging/commands.js
+++ b/src/table-dragging/commands.js
@@ -19,13 +19,13 @@ export const switchRows = (
   );
 
   const newTr = tr || view.state.tr;
-  // No need for typeInheritance because we haven't changed column types or add new cells.
   newTr.replaceWith(
     tableRect.tableStart,
     tableRect.tableStart + tableRect.table.content.size,
     rowsSlice
   );
   newTr.setSelection(Selection.near(newTr.doc.resolve(selPos), 1));
+  // No need for typeInheritance because we haven't changed column types or add new cells.
 
   if (tr) {
     return newTr;
@@ -56,8 +56,8 @@ export const switchCols = (
     tableRect.tableStart + tableRect.table.content.size,
     newRowsSlice
   );
-  typeInheritance(newTr, tableRect.tableStart);
   newTr.setSelection(Selection.near(newTr.doc.resolve(selPos), 1));
+  // No need for typeInheritance because we also switch the column headers (hence types).
 
   if (tr) {
     return newTr;

--- a/src/table-dragging/commands.js
+++ b/src/table-dragging/commands.js
@@ -1,4 +1,5 @@
 import {Selection} from 'prosemirror-state';
+import {typeInheritance} from '../columnsTypes/typeInheritance';
 
 export const switchRows = (
   view,
@@ -18,6 +19,7 @@ export const switchRows = (
   );
 
   const newTr = tr || view.state.tr;
+  // No need for typeInheritance because we haven't changed column types or add new cells.
   newTr.replaceWith(
     tableRect.tableStart,
     tableRect.tableStart + tableRect.table.content.size,
@@ -53,6 +55,11 @@ export const switchCols = (
     tableRect.tableStart,
     tableRect.tableStart + tableRect.table.content.size,
     newRowsSlice
+  );
+  typeInheritance(
+    newTr,
+    newTr.doc.nodeAt(tableRect.tableStart - 1),
+    tableRect.tableStart
   );
   newTr.setSelection(Selection.near(newTr.doc.resolve(selPos), 1));
 

--- a/src/table-dragging/commands.js
+++ b/src/table-dragging/commands.js
@@ -56,11 +56,7 @@ export const switchCols = (
     tableRect.tableStart + tableRect.table.content.size,
     newRowsSlice
   );
-  typeInheritance(
-    newTr,
-    newTr.doc.nodeAt(tableRect.tableStart - 1),
-    tableRect.tableStart
-  );
+  typeInheritance(newTr, tableRect.tableStart);
   newTr.setSelection(Selection.near(newTr.doc.resolve(selPos), 1));
 
   if (tr) {

--- a/src/table-dragging/commands.js
+++ b/src/table-dragging/commands.js
@@ -1,5 +1,4 @@
 import {Selection} from 'prosemirror-state';
-import {typeInheritance} from '../columnsTypes/typeInheritance';
 
 export const switchRows = (
   view,

--- a/src/tableview.js
+++ b/src/tableview.js
@@ -1,7 +1,6 @@
 import {NodeSelection} from 'prosemirror-state';
 import {addBottomRow, addRightColumn} from './commands';
 import {createButtonWithIcon, createElementWithClass} from './util';
-import {typeInheritance} from './headers/headers-menu/index';
 import {tableFiltersMenuKey} from './filters/utils';
 import {tableHeadersMenuKey} from './columnsTypes/types.config';
 
@@ -177,9 +176,6 @@ export class TableView {
       return false;
     }
     this.buildActiveFiltersButton(node);
-    if (this.node.attrs.headers) {
-      typeInheritance(this.view, node, this.getPos());
-    }
 
     if (!this.node.sameMarkup(node)) {
       return false;


### PR DESCRIPTION
**Bug**
New rows were not inheriting cell types. It appears `typeInheritance.js` was running, but being overwritten by y-prosemirror. Possibly y-prosemirror got confused by `typeInheritance`'s dispatching a transaction in the middle of another, causing the outer (earlier) transaction to overwrite the inner during Yjs sync.

**Changes**
- Instead of running `typeInheritance` in the Table NodeView's update method, we run it directly at the end of changes that insert cells or change a column's type.
  - In codepaths that we don't actually use because they concern merged cells (which we don't allow), I just put a TODO for in case we ever allow merging in the future.
- Change `typeInheritance`'s signature slightly to accommodate this new usage.
- Fixed misc bugs in `typeInheritance`'s code.

**Testing**
- Manual:
  - Adding rows to bottom or middle of table correctly sets the new cells' types, and puts the selection in the first text-containing cell as expected. Also works with multiple viewers (no weird back-and-forth).
  - Adding rows to an old malformed table (w/o inherited cell types) works, although it doesn't repair the old cells.
  - Pasting cells into a table works: the cells inherit their new columns' types, and growing the table works. Also, the selection is set to the content of the last pasted cell - maybe not ideal, but the same as before.
  - Adding columns in the middle or end works as before. Note these are always type text, which doesn't actually need inheriting.