### PR TITLE
Omit useClickOutside click case

### DIFF
--- a/src/columnsTypes/types/Date/Component.jsx
+++ b/src/columnsTypes/types/Date/Component.jsx
@@ -69,6 +69,10 @@ export const DatePickerComponent = ({view, node, pos}) => {
   const ref = useClickOutside((e) => {
     if (!view.dom.contains(e.target)) return;
 
+    // Skip click events, only listen for Esc events.
+    // See https://linear.app/skiff/issue/ENG-3320/table-date-picker-breaks-if-you-click-directly-from-one-cell-to
+    if (e.type === 'click') return;
+
     const {tr} = view.state;
     tr.setMeta(tableDateMenuKey, {
       id: window.id,

--- a/src/useClickOutside.jsx
+++ b/src/useClickOutside.jsx
@@ -9,7 +9,7 @@ const useClickOutside = (onClose, eventType) => {
   const escapeListener = useCallback(
     (e) => {
       if (e.key === 'Escape') {
-        onClose();
+        onClose?.(e);
       }
     },
     [onClose]


### PR DESCRIPTION
See https://linear.app/skiff/issue/ENG-3320/table-date-picker-breaks-if-you-click-directly-from-one-cell-to - this is the "for now" patch described there.

Also fixes a typo in the `Esc` case of `useClickOutside`, which previously caused an error if you exited using `Esc`.

Testing: Clicked in, out, and directly between Date cells a bunch and saw no issue. Exiting out of Date cells or labels using Esc also works.